### PR TITLE
DOC: Syncs instructions with doomemacs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,8 +22,8 @@ operating system.
 ### Quick install
 
 ``` sh
-git clone --depth 1 --single-branch https://github.com/doomemacs/doomemacs ~/.config/emacs
-~/.config/emacs/bin/doom install
+git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.emacs.d
+~/.emacs.d/bin/doom install
 ```
 
 


### PR DESCRIPTION
A small fix for the quick install instructions to make it more beginner friendly.

emacs uses `~/.emacs.d` by default, the earlier instructions were cloning to `~/.config/emacs`.
 
Someone trying to use doom emacs for the first time might find this confusing.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
